### PR TITLE
feat: 기본 페이지 크기를 10에서 50으로 증가

### DIFF
--- a/internal/cmd/admrule_search.go
+++ b/internal/cmd/admrule_search.go
@@ -37,7 +37,7 @@ func initAdmruleSearchCmd() {
 	// Flags
 	admruleSearchCmd.Flags().StringVarP(&admrOutputFormat, "format", "f", "table", "출력 형식 (table, json)")
 	admruleSearchCmd.Flags().IntVarP(&admrPageNo, "page", "p", 1, "페이지 번호")
-	admruleSearchCmd.Flags().IntVarP(&admrPageSize, "size", "s", 10, "페이지 크기")
+	admruleSearchCmd.Flags().IntVarP(&admrPageSize, "size", "s", 50, "페이지 크기")
 }
 
 // updateAdmruleSearchCommand updates administrative rule search command descriptions

--- a/internal/cmd/interpretation_search.go
+++ b/internal/cmd/interpretation_search.go
@@ -37,7 +37,7 @@ func initInterpretationSearchCmd() {
 	// Flags
 	interpretationSearchCmd.Flags().StringVarP(&interpOutputFormat, "format", "f", "table", "출력 형식 (table, json)")
 	interpretationSearchCmd.Flags().IntVarP(&interpPageNo, "page", "p", 1, "페이지 번호")
-	interpretationSearchCmd.Flags().IntVarP(&interpPageSize, "size", "s", 10, "페이지 크기")
+	interpretationSearchCmd.Flags().IntVarP(&interpPageSize, "size", "s", 50, "페이지 크기")
 }
 
 // updateInterpretationSearchCommand updates legal interpretation search command descriptions

--- a/internal/cmd/law.go
+++ b/internal/cmd/law.go
@@ -65,7 +65,7 @@ func initLawCmd() {
 	// Flags for backward compatibility (when using law without subcommand)
 	lawCmd.Flags().StringVarP(&outputFormat, "format", "f", "table", i18n.T("law.flag.format"))
 	lawCmd.Flags().IntVarP(&pageNo, "page", "p", 1, i18n.T("law.flag.page"))
-	lawCmd.Flags().IntVarP(&pageSize, "size", "s", 10, i18n.T("law.flag.size"))
+	lawCmd.Flags().IntVarP(&pageSize, "size", "s", 50, i18n.T("law.flag.size"))
 	lawCmd.Flags().StringVar(&sourceFlag, "source", "nlic", i18n.T("law.flag.source"))
 }
 

--- a/internal/cmd/law_search.go
+++ b/internal/cmd/law_search.go
@@ -42,7 +42,7 @@ func initLawSearchCmd() {
 	// Flags
 	lawSearchCmd.Flags().StringVarP(&outputFormat, "format", "f", "table", i18n.T("law.flag.format"))
 	lawSearchCmd.Flags().IntVarP(&pageNo, "page", "p", 1, i18n.T("law.flag.page"))
-	lawSearchCmd.Flags().IntVarP(&pageSize, "size", "s", 10, i18n.T("law.flag.size"))
+	lawSearchCmd.Flags().IntVarP(&pageSize, "size", "s", 50, i18n.T("law.flag.size"))
 	lawSearchCmd.Flags().StringVar(&sourceFlag, "source", "nlic", i18n.T("law.flag.source"))
 }
 

--- a/internal/cmd/ordinance.go
+++ b/internal/cmd/ordinance.go
@@ -67,7 +67,7 @@ func initOrdinanceCmd() {
 	// Flags
 	ordinanceCmd.PersistentFlags().StringVarP(&ordinanceOutputFormat, "format", "f", "table", i18n.T("ordinance.flag.format"))
 	ordinanceCmd.PersistentFlags().IntVarP(&ordinancePageNo, "page", "p", 1, i18n.T("ordinance.flag.page"))
-	ordinanceCmd.PersistentFlags().IntVarP(&ordinancePageSize, "size", "s", 10, i18n.T("ordinance.flag.size"))
+	ordinanceCmd.PersistentFlags().IntVarP(&ordinancePageSize, "size", "s", 50, i18n.T("ordinance.flag.size"))
 	ordinanceCmd.PersistentFlags().StringVarP(&ordinanceRegion, "region", "r", "", i18n.T("ordinance.flag.region"))
 	ordinanceCmd.PersistentFlags().StringVar(&ordinanceSort, "sort", "date", i18n.T("ordinance.flag.sort"))
 }

--- a/internal/cmd/precedent_search.go
+++ b/internal/cmd/precedent_search.go
@@ -37,7 +37,7 @@ func initPrecedentSearchCmd() {
 	// Flags
 	precedentSearchCmd.Flags().StringVarP(&precOutputFormat, "format", "f", "table", "출력 형식 (table, json)")
 	precedentSearchCmd.Flags().IntVarP(&precPageNo, "page", "p", 1, "페이지 번호")
-	precedentSearchCmd.Flags().IntVarP(&precPageSize, "size", "s", 10, "페이지 크기")
+	precedentSearchCmd.Flags().IntVarP(&precPageSize, "size", "s", 50, "페이지 크기")
 }
 
 // updatePrecedentSearchCommand updates precedent search command descriptions


### PR DESCRIPTION
## Summary
- 모든 검색 명령의 기본 페이지 크기를 10에서 50으로 증가시켜 사용자 경험을 개선했습니다.
- 대부분의 검색 결과를 페이지네이션 없이 한 번에 볼 수 있게 되었습니다.

## Changes
- `internal/cmd/law.go`: 법령 검색 기본 페이지 크기 변경
- `internal/cmd/law_search.go`: 법령 검색 실행 시 기본값 변경
- `internal/cmd/precedent_search.go`: 판례 검색 기본 페이지 크기 변경
- `internal/cmd/admrule_search.go`: 행정규칙 검색 기본 페이지 크기 변경
- `internal/cmd/interpretation_search.go`: 법령해석례 검색 기본 페이지 크기 변경
- `internal/cmd/ordinance.go`: 자치법규 검색 기본 페이지 크기 변경

## Test Results
테스트 완료:
```bash
./sejong law "개인정보"
```
결과: 12개의 검색 결과가 한 번에 표시됨 (이전에는 10개만 표시)

## Related Issue
Fixes #31