### PR TITLE
refactor: lang 옵션 제거 및 한국어 고정

### DIFF
--- a/internal/cmd/config_test.go
+++ b/internal/cmd/config_test.go
@@ -17,7 +17,6 @@ func TestConfigCommand(t *testing.T) {
 	if err := i18n.Init(); err != nil {
 		t.Fatalf("Failed to initialize i18n: %v", err)
 	}
-	i18n.SetLanguage("ko")
 
 	// Initialize config commands
 	initConfigCmd()
@@ -84,7 +83,6 @@ func TestConfigSetCommand(t *testing.T) {
 	if err := i18n.Init(); err != nil {
 		t.Fatalf("Failed to initialize i18n: %v", err)
 	}
-	i18n.SetLanguage("ko")
 
 	// Initialize config commands
 	initConfigCmd()
@@ -198,7 +196,6 @@ func TestConfigGetCommand(t *testing.T) {
 	if err := i18n.Init(); err != nil {
 		t.Fatalf("Failed to initialize i18n: %v", err)
 	}
-	i18n.SetLanguage("ko")
 
 	// Initialize config commands
 	initConfigCmd()
@@ -321,7 +318,6 @@ func TestConfigPathCommand(t *testing.T) {
 	if err := i18n.Init(); err != nil {
 		t.Fatalf("Failed to initialize i18n: %v", err)
 	}
-	i18n.SetLanguage("ko")
 
 	// Initialize config commands
 	initConfigCmd()

--- a/internal/cmd/law_subcommands_test.go
+++ b/internal/cmd/law_subcommands_test.go
@@ -14,7 +14,6 @@ func TestLawSubcommands(t *testing.T) {
 	if err := i18n.Init(); err != nil {
 		t.Fatalf("Failed to initialize i18n: %v", err)
 	}
-	i18n.SetLanguage("ko")
 
 	// Initialize law command
 	initLawCmd()
@@ -156,7 +155,6 @@ func TestLawBackwardCompatibility(t *testing.T) {
 	if err := i18n.Init(); err != nil {
 		t.Fatalf("Failed to initialize i18n: %v", err)
 	}
-	i18n.SetLanguage("ko")
 
 	// Initialize law command
 	initLawCmd()

--- a/internal/cmd/law_test.go
+++ b/internal/cmd/law_test.go
@@ -21,7 +21,6 @@ func TestLawCommand(t *testing.T) {
 	if err := i18n.Init(); err != nil {
 		t.Fatalf("Failed to initialize i18n: %v", err)
 	}
-	i18n.SetLanguage("ko")
 
 	// Initialize law command
 	initLawCmd()
@@ -105,7 +104,6 @@ func TestLawCommandFlags(t *testing.T) {
 	if err := i18n.Init(); err != nil {
 		t.Fatalf("Failed to initialize i18n: %v", err)
 	}
-	i18n.SetLanguage("ko")
 
 	// Initialize law command
 	initLawCmd()
@@ -143,7 +141,6 @@ func TestLawCommandWithAPIKey(t *testing.T) {
 	if err := i18n.Init(); err != nil {
 		t.Fatalf("Failed to initialize i18n: %v", err)
 	}
-	i18n.SetLanguage("ko")
 
 	// Initialize law command
 	initLawCmd()
@@ -307,7 +304,6 @@ func TestLawCommandNoAPIKey(t *testing.T) {
 	if err := i18n.Init(); err != nil {
 		t.Fatalf("Failed to initialize i18n: %v", err)
 	}
-	i18n.SetLanguage("ko")
 
 	// Initialize law command
 	initLawCmd()
@@ -355,7 +351,6 @@ func TestSearchLaws(t *testing.T) {
 	if err := i18n.Init(); err != nil {
 		t.Fatalf("Failed to initialize i18n: %v", err)
 	}
-	i18n.SetLanguage("ko")
 
 	// Test with mock client
 	mockClient := &mockAPIClient{

--- a/internal/cmd/ordinance_test.go
+++ b/internal/cmd/ordinance_test.go
@@ -63,7 +63,6 @@ func (m *MockOrdinanceClient) GetAPIType() api.APIType {
 func TestOrdinanceCommand(t *testing.T) {
 	// Initialize i18n for testing
 	i18n.Init()
-	i18n.SetLanguage("ko")
 
 	// Set up mock client
 	mockClient := &MockOrdinanceClient{}
@@ -146,7 +145,6 @@ func TestOrdinanceCommand(t *testing.T) {
 func TestOrdinanceSearchCommand(t *testing.T) {
 	// Initialize i18n for testing
 	i18n.Init()
-	i18n.SetLanguage("ko")
 
 	// Set up mock client
 	mockClient := &MockOrdinanceClient{}
@@ -235,7 +233,6 @@ func TestOrdinanceSearchCommand(t *testing.T) {
 func TestOrdinanceDetailCommand(t *testing.T) {
 	// Initialize i18n for testing
 	i18n.Init()
-	i18n.SetLanguage("ko")
 
 	// Set up mock client
 	mockClient := &MockOrdinanceClient{}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -18,8 +18,6 @@ var (
 	BuildDate = "unknown"
 	GitCommit = "unknown"
 
-	// Language flag
-	langFlag string
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -39,15 +37,6 @@ func initRootCmd() {
   
   # API 키 설정
   sejong config set law.key YOUR_API_KEY`,
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			// Set language if specified
-			if langFlag != "" {
-				i18n.SetLanguage(langFlag)
-				// Re-initialize commands with new language
-				updateCommandDescriptions()
-			}
-			return nil
-		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// If no subcommand is provided, show help
 			return cmd.Help()
@@ -121,8 +110,6 @@ func setupFlags() {
 	// Initialize configuration
 	cobra.OnInitialize(initConfig)
 
-	// Language flag
-	rootCmd.PersistentFlags().StringVar(&langFlag, "lang", "", "Language (ko, en)")
 
 	// Global flags
 	rootCmd.PersistentFlags().BoolP("verbose", "v", false, i18n.T("cli.verbose"))

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -14,7 +14,6 @@ func TestRootCommand(t *testing.T) {
 	if err := i18n.Init(); err != nil {
 		t.Fatalf("Failed to initialize i18n: %v", err)
 	}
-	i18n.SetLanguage("ko")
 
 	// Initialize root command
 	initRootCmd()

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -4,8 +4,6 @@ import (
 	"embed"
 	"encoding/json"
 	"fmt"
-	"os"
-	"strings"
 
 	"github.com/nicksnyder/go-i18n/v2/i18n"
 	"golang.org/x/text/language"
@@ -17,7 +15,6 @@ var messagesFS embed.FS
 var (
 	bundle    *i18n.Bundle
 	localizer *i18n.Localizer
-	langFlag  string // Language set by --lang flag
 )
 
 // Init initializes the i18n system
@@ -46,67 +43,13 @@ func Init() error {
 	return nil
 }
 
-// SetLanguage sets the language for the application
-func SetLanguage(lang string) {
-	langFlag = lang
-	localizer = i18n.NewLocalizer(bundle, lang)
-}
 
-// detectLanguage detects the user's preferred language
+// detectLanguage always returns Korean as this is a Korean law information tool
 func detectLanguage() string {
-	// Priority 1: --lang flag (set by SetLanguage)
-	if langFlag != "" {
-		return langFlag
-	}
-
-	// Priority 2: LANG environment variable
-	if envLang := os.Getenv("LANG"); envLang != "" {
-		lang := parseLocale(envLang)
-		if lang != "" {
-			return lang
-		}
-	}
-
-	// Priority 3: LC_ALL environment variable
-	if lcAll := os.Getenv("LC_ALL"); lcAll != "" {
-		lang := parseLocale(lcAll)
-		if lang != "" {
-			return lang
-		}
-	}
-
-	// Default: Korean
+	// Always return Korean - this is a Korean law information tool
 	return "ko"
 }
 
-// parseLocale extracts the language code from a locale string
-// Handles formats like: en_US.UTF-8, en-US.UTF-8, ko_KR.UTF-8, C.UTF-8
-func parseLocale(locale string) string {
-	// Handle special case for C locale
-	if locale == "C" || strings.HasPrefix(locale, "C.") {
-		return "" // Use default
-	}
-
-	// Remove encoding suffix (e.g., ".UTF-8")
-	if idx := strings.Index(locale, "."); idx != -1 {
-		locale = locale[:idx]
-	}
-
-	// Replace '-' with '_' for consistency
-	locale = strings.ReplaceAll(locale, "-", "_")
-
-	// Split on '_' and take the first part
-	parts := strings.Split(locale, "_")
-	if len(parts) > 0 {
-		lang := strings.ToLower(parts[0])
-		// Only return if it's a supported language
-		if lang == "ko" || lang == "en" {
-			return lang
-		}
-	}
-
-	return "" // Use default
-}
 
 // T translates a message
 func T(messageID string, data ...map[string]interface{}) string {
@@ -142,8 +85,5 @@ func Tf(messageID string, args ...interface{}) string {
 
 // GetCurrentLanguage returns the current language code
 func GetCurrentLanguage() string {
-	if langFlag != "" {
-		return langFlag
-	}
 	return detectLanguage()
 }

--- a/test/e2e/law_search_test.go
+++ b/test/e2e/law_search_test.go
@@ -33,7 +33,7 @@ func TestE2EFirstUserScenario(t *testing.T) {
 
 	// Scenario 1: Search without API key - should show guidance
 	t.Run("SearchWithoutAPIKey", func(t *testing.T) {
-		cmd := exec.Command(getSejongPath(), "--lang", "ko", "law", "개인정보 보호법")
+		cmd := exec.Command(getSejongPath(), "law", "개인정보 보호법")
 		cmd.Env = append(os.Environ(), fmt.Sprintf("HOME=%s", tempDir))
 
 		output, err := cmd.CombinedOutput()
@@ -46,7 +46,7 @@ func TestE2EFirstUserScenario(t *testing.T) {
 
 	// Scenario 2: Set API key
 	t.Run("SetAPIKey", func(t *testing.T) {
-		cmd := exec.Command(getSejongPath(), "--lang", "ko", "config", "set", "law.key", "TEST_API_KEY")
+		cmd := exec.Command(getSejongPath(), "config", "set", "law.key", "TEST_API_KEY")
 		cmd.Env = append(os.Environ(), fmt.Sprintf("HOME=%s", tempDir))
 
 		output, err := cmd.CombinedOutput()
@@ -58,7 +58,7 @@ func TestE2EFirstUserScenario(t *testing.T) {
 
 	// Scenario 3: Verify API key is set
 	t.Run("GetAPIKey", func(t *testing.T) {
-		cmd := exec.Command(getSejongPath(), "--lang", "en", "config", "get", "law.key")
+		cmd := exec.Command(getSejongPath(), "config", "get", "law.key")
 		cmd.Env = append(os.Environ(), fmt.Sprintf("HOME=%s", tempDir))
 
 		output, err := cmd.CombinedOutput()
@@ -231,7 +231,7 @@ func TestE2EErrorScenarios(t *testing.T) {
 func TestE2EVersionAndHelp(t *testing.T) {
 	// Test version command
 	t.Run("VersionCommand", func(t *testing.T) {
-		cmd := exec.Command(getSejongPath(), "--lang", "en", "version")
+		cmd := exec.Command(getSejongPath(), "version")
 		output, err := cmd.CombinedOutput()
 		require.NoError(t, err, "Command failed: %s", string(output))
 


### PR DESCRIPTION
## Summary
Sejong CLI는 한국 법령 정보 검색 도구이므로 언어 선택 기능을 제거하고 한국어를 기본 언어로 고정했습니다.

## Changes
- `--lang` 플래그 완전 제거
- `i18n.SetLanguage()` 함수 제거  
- `detectLanguage()`가 항상 'ko'를 반환하도록 단순화
- 사용되지 않는 `parseLocale()` 함수 제거
- 테스트 코드에서 `SetLanguage` 호출 모두 제거

## Impact
- 코드가 단순해지고 유지보수가 쉬워졌습니다
- 한국 법령 정보 도구로서의 목적이 더 명확해졌습니다
- 불필요한 복잡성이 제거되었습니다

## Test Results
✅ 모든 테스트 통과
```bash
go test ./internal/cmd -short
# ok  github.com/pyhub-apps/sejong-cli/internal/cmd  0.598s
```

## Related Issue
Fixes #29